### PR TITLE
Use `CMAKE_INSTALL_*` variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,11 +78,11 @@ add_executable(fasttext-bin src/main.cc)
 target_link_libraries(fasttext-bin pthread fasttext-static)
 set_target_properties(fasttext-bin PROPERTIES PUBLIC_HEADER "${HEADER_FILES}" OUTPUT_NAME fasttext)
 install (TARGETS fasttext-shared
-    LIBRARY DESTINATION lib)
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install (TARGETS fasttext-static
-    ARCHIVE DESTINATION lib)
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install (TARGETS fasttext-static_pic
-    ARCHIVE DESTINATION lib)
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install (TARGETS fasttext-bin
-    RUNTIME DESTINATION bin
- PUBLIC_HEADER DESTINATION include/fasttext)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fasttext)


### PR DESCRIPTION
Replace hard-coded directories with cmake variables to support installation in `/usr/lib64` or buildroot.

Source: https://src.fedoraproject.org/rpms/fasttext/blob/f38/f/enable-install-lib64.patch
See: https://cmake.org/cmake/help/latest/command/install.html#signatures