### PR TITLE
Fix 'uint64_t' was not declared in this scope

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -9,6 +9,7 @@
 #include "args.h"
 
 #include <cstdlib>
+#include <cstdint>
 
 #include <iostream>
 #include <stdexcept>


### PR DESCRIPTION
The code fails to build from source with GCC 13.1 because `uint64_t` is not defined.

```
src/args.cc: In member function 'int64_t fasttext::Args::getAutotuneModelSize() const':
src/args.cc:468:3: error: 'uint64_t' was not declared in this scope
  468 |   uint64_t multiplier = 1;
      |   ^~~~~~~~
src/args.cc:17:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   16 | #include <unordered_map>
  +++ |+#include <cstdint>
```